### PR TITLE
build: run tests in test job, run quality in quality job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,5 @@ jobs:
 
     - name: Run Tests
       run: make test
+      env:
+        TOXENV: ${{ matrix.toxenv }}


### PR DESCRIPTION
./.github/workflows/ci.yml was not passing the TOXENV
environment variable into `make test`, so both the 'py38'
and 'quality' GitHub Action jobs were running both
unit tests and quality checks.