### PR TITLE
feat: Add `symmath` star import

### DIFF
--- a/calc/__init__.py
+++ b/calc/__init__.py
@@ -6,4 +6,4 @@ backwards compatibility
 
 from .calc import *
 
-__version__ = '3.0.0'
+__version__ = '3.0.1'

--- a/symmath/__init__.py
+++ b/symmath/__init__.py
@@ -1,0 +1,3 @@
+# lint-amnesty, pylint: disable=missing-module-docstring
+from .formula import *
+from .symmath_check import *


### PR DESCRIPTION
This feature was not ported over when `symmath` was moved to `openedx-calc` from `edx-platform`. In order to make the transition easier, it is being re-included. To reflect this minor change, openedx-calc has been bumped up a minor version.