### PR TITLE
feanil/upadate to python311

### DIFF
--- a/calc/__init__.py
+++ b/calc/__init__.py
@@ -6,4 +6,4 @@ backwards compatibility
 
 from .calc import *
 
-__version__ = '3.0.1'
+__version__ = '3.1.0'

--- a/calc/calc.py
+++ b/calc/calc.py
@@ -127,7 +127,11 @@ def eval_number(parse_result):
     e.g. [ '7.13', 'e', '3' ] ->  7130
     Calls super_float above.
     """
-    return super_float("".join(parse_result))
+    for item in parse_result:
+        if "." in item or "e" in item or "E" in item:
+            return super_float("".join(parse_result))
+
+    return int("".join(parse_result))
 
 
 def eval_atom(parse_result):
@@ -185,7 +189,7 @@ def eval_sum(parse_result):
 
     Allow a leading + or -.
     """
-    total = 0.0
+    total = 0
     current_op = operator.add
     for token in parse_result:
         if token == '+':
@@ -203,7 +207,7 @@ def eval_product(parse_result):
 
     [ 1, '*', 2, '/', 3 ] -> 0.66
     """
-    prod = 1.0
+    prod = 1
     current_op = operator.mul
     for token in parse_result:
         if token == '*':

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -348,9 +348,9 @@ class EvaluatorTest(unittest.TestCase):
         self.assert_function_values('factorial', fact_inputs, fact_values)
 
         self.assertRaises(ValueError, calc.evaluator, {}, {}, "fact(-1)")
-        self.assertRaises(ValueError, calc.evaluator, {}, {}, "fact(0.5)")
+        self.assertRaises((ValueError, TypeError), calc.evaluator, {}, {}, "fact(0.5)")
         self.assertRaises(ValueError, calc.evaluator, {}, {}, "factorial(-1)")
-        self.assertRaises(ValueError, calc.evaluator, {}, {}, "factorial(0.5)")
+        self.assertRaises((ValueError, TypeError), calc.evaluator, {}, {}, "factorial(0.5)")
 
     def test_constants(self):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = py38,quality
+envlist = py{38,311},quality
 
 [testenv]
 allowlist_externals =
 	touch
 deps =
+    setuptools
 	-r requirements/test.txt
 commands =
 	coverage run setup.py test
@@ -12,6 +13,7 @@ commands =
 
 [testenv:quality]
 deps =
+    setuptools
 	-r requirements/test.txt
 commands =
 	pycodestyle calc symmath tests


### PR DESCRIPTION
An alternative proposal to https://github.com/openedx/openedx-calc/pull/102 for dealing with the fact that the `factiorial` function does not auto coerce floats to integers anymore.

- **chore: Updating Python Requirements**
- **chore: Update pylintrc from edx-lint.**
- **fix: Fix new pylint warnings.**
- **feat: Add python 3.11 support.**
