### PR TITLE
fix: evaluate integer percentage

### DIFF
--- a/calc/calc.py
+++ b/calc/calc.py
@@ -79,7 +79,7 @@ DEFAULT_VARIABLES = {
 }
 
 SUFFIXES = {
-    '%': 0.01,
+    '%': lambda x: x * 0.01,
 }
 
 
@@ -114,22 +114,23 @@ def super_float(text):
     """
     Evaluate suffixes if applicable and apply float.
     """
-    if text[-1] in SUFFIXES:
-        return float(text[:-1]) * SUFFIXES[text[-1]]
-    else:
-        return float(text)
+    func = SUFFIXES[text[-1]]
+    return func(float(text[:-1]))
 
 
 def eval_number(parse_result):
     """
-    Create a float out of its string parts.
+    Returns an int or a float from string parts.
+    Calls super_float above for suffix evaluation.
 
     e.g. [ '7.13', 'e', '3' ] ->  7130
-    Calls super_float above.
     """
+    if parse_result[-1] in SUFFIXES:
+        return super_float("".join(parse_result))
+
     for item in parse_result:
-        if "." in item or "e" in item or "E" in item or parse_result[-1] in SUFFIXES:
-            return super_float("".join(parse_result))
+        if "." in item or "e" in item or "E" in item:
+            return float("".join(parse_result))
 
     return int("".join(parse_result))
 

--- a/calc/calc.py
+++ b/calc/calc.py
@@ -112,7 +112,7 @@ def lower_dict(input_dict):
 
 def super_float(text):
     """
-    Like float, but with SI extensions. 1k goes to 1000.
+    Evaluate suffixes if applicable and apply float.
     """
     if text[-1] in SUFFIXES:
         return float(text[:-1]) * SUFFIXES[text[-1]]
@@ -128,7 +128,7 @@ def eval_number(parse_result):
     Calls super_float above.
     """
     for item in parse_result:
-        if "." in item or "e" in item or "E" in item:
+        if "." in item or "e" in item or "E" in item or parse_result[-1] in SUFFIXES:
             return super_float("".join(parse_result))
 
     return int("".join(parse_result))

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -93,7 +93,11 @@ class EvaluatorTest(unittest.TestCase):
         For instance '%' stand for 1/100th so '1%' should be 0.01
         """
         test_mapping = [
-            ('4.2%', 0.042)
+            ('4.2%', 0.042),
+            ('1%', 0.01),
+            ('0.5%', 0.005),
+            ('70%', 0.7),
+            ('-50%', -0.5)
         ]
 
         for (expr, answer) in test_mapping:


### PR DESCRIPTION
Currently, an integer percentage answer like "1%" does not evaluate as a number while "1.0%" does. This is due to the % suffix not being evaluated when there is no "." in the answer. This PR fixes this issue.