### PR TITLE
chore: version bump

### DIFF
--- a/calc/__init__.py
+++ b/calc/__init__.py
@@ -6,4 +6,4 @@ backwards compatibility
 
 from .calc import *
 
-__version__ = '3.1.0'
+__version__ = '3.1.2'


### PR DESCRIPTION
The previous change did not bump versioning so the Publish Package to PyPI did not run successfully. This PR bumps the versioning so the package files are not built with a the previous version in its file names.